### PR TITLE
Add auto-author-assign.yml Action

### DIFF
--- a/.github/workflows/auto-author-assign.yml
+++ b/.github/workflows/auto-author-assign.yml
@@ -1,0 +1,22 @@
+# Code copied from example in 
+# https://github.com/marketplace/actions/auto-author-assign
+
+# .github/workflows/auto-author-assign.yml
+name: Auto Author Assign
+
+on:
+  pull_request_target:
+    types: [ opened, reopened ]
+
+permissions:
+  pull-requests: write
+
+# This action automatically assigns the pull request author as an assignee.
+# The auto-author-assign action skips assigning the author when:
+#   -  Someone is already assigned as an assignee
+#   -  The author is a bot
+jobs:
+  assign-author:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: toshimaru/auto-author-assign@v2.1.1


### PR DESCRIPTION
# Description

### What has been done?
Added a workflow that auto assigns the author of a PR as the assignee.

### Why did you do this?
To automate a repetetive (& boring) task that is often overlooked otherwise.
closes [issue nr. 17 in health-care branch](https://github.com/simon-s-99/health-care/issues/17)

#

### Reviewer
When PR is ready to be closed & merged reviewer should 'Squash & Merge' the entire PR to retain a readable commit history in target branch.
